### PR TITLE
Add support for calling commands by attr access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
 
 install:
-  - "python setup.py build"
+  - "python setup.py install"
 
 script: "python test.py"
 

--- a/hirlite/__init__.py
+++ b/hirlite/__init__.py
@@ -8,4 +8,6 @@ __all__ = ["Rlite", "HirliteError", "__version__"]
 
 class Rlite(RliteExtension):
     def __getattr__(self, command):
+        if command == 'delete':
+            command = 'del'
         return functools.partial(self.command, command)

--- a/hirlite/__init__.py
+++ b/hirlite/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import functools
 
 from hirlite.hirlite import Rlite as RliteExtension, HirliteError

--- a/hirlite/__init__.py
+++ b/hirlite/__init__.py
@@ -1,4 +1,11 @@
-from .hirlite import Rlite, HirliteError
-from .version import __version__
+import functools
+
+from hirlite.hirlite import Rlite as RliteExtension, HirliteError
+from hirlite.version import __version__
 
 __all__ = ["Rlite", "HirliteError", "__version__"]
+
+
+class Rlite(RliteExtension):
+    def __getattr__(self, command):
+        return functools.partial(self.command, command)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,17 +1,14 @@
-import glob, os.path, sys
+import unittest
+import sys
 
-version = sys.version.split(" ")[0]
-majorminor = version[0:3]
+# make sure hirlite isn't imported from source
+sys.path = sys.path[1:]
 
-# Add path to hiredis.so load path
-path = glob.glob("build/lib*-%s/hirlite" % majorminor)[0]
-sys.path.insert(0, path)
-
-from unittest import *
-from . import rlite, persistent
 
 def tests():
-  suite = TestSuite()
-  suite.addTest(makeSuite(rlite.RliteTest))
-  suite.addTest(makeSuite(persistent.PersistentTest))
-  return suite
+    from test import rlite, persistent
+
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(rlite.RliteTest))
+    suite.addTest(unittest.makeSuite(persistent.PersistentTest))
+    return suite

--- a/test/rlite.py
+++ b/test/rlite.py
@@ -39,3 +39,15 @@ class RliteTest(TestCase):
     def test_array(self):
         self.rlite.command('rpush', 'mylist', '1', '2', '3')
         self.assertEquals(self.rlite.command('lrange', 'mylist', '0', '-1'), [b'1', b'2', b'3'])
+
+    def test_getattr(self):
+        self.assertTrue(self.rlite.set('x', b'y'))
+        self.assertEqual(self.rlite.get('x'), b'y')
+        self.assertEqual(self.rlite.delete('x'), 1)
+        self.assertEqual(self.rlite.exists('x'), 0)
+
+    def test_getattr_err(self):
+        command = 'invalidcommand'
+        res = getattr(self.rlite, command)()
+        self.assertTrue(isinstance(res, hirlite.HirliteError))
+        self.assertEqual(res.args[0], "unknown command '%s'" % command)


### PR DESCRIPTION
Adds support for calling rlite commands by accessing attributes in `hirlite.hirlite.Rlite`.

Until `hirlite.hirlite.Rlite` gets more attributes than `command`, we can make the assumption that by accessing any attribute, we mean calling command.

Unfortunately, I'm not too familiar with writing C extensions -- `hirlite.Rlite` is now written in Python and is a subclass of `hirlite.hirlite.Rlite`. C doesn't support currying functions, so in order to achieve this we should either use `functools.partial` from C (which gives us nothing over this solution) or modify `rlite.c` a bit more.

Additionally, I have changed relative imports to absolute.
