### PR TITLE
redis-py patching support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,14 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
+
+env:
+  - "REDIS_PATCH=true"
+  - "REDIS_PATCH=false"
 
 install:
+  - "if [ $REDIS_PATCH == true ]; then pip install redis; fi"
   - "python setup.py install"
 
 script: "python test.py"

--- a/hirlite/__init__.py
+++ b/hirlite/__init__.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 import functools
 
 from hirlite.hirlite import Rlite as RliteExtension, HirliteError
-from hirlite.patch_conn import patch_connection
+from hirlite.patch_conn import patch_connection, unpatch_connection, patch
 from hirlite.version import __version__
 
-__all__ = ["Rlite", "patch_connection", "HirliteError", "__version__"]
+__all__ = ["Rlite", "patch_connection", "unpatch_connection", "patch", "HirliteError", "__version__"]
 
 
 class Rlite(RliteExtension):

--- a/hirlite/__init__.py
+++ b/hirlite/__init__.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import functools
 
 from hirlite.hirlite import Rlite as RliteExtension, HirliteError
+from hirlite.patch_conn import patch_connection
 from hirlite.version import __version__
 
-__all__ = ["Rlite", "HirliteError", "__version__"]
+__all__ = ["Rlite", "patch_connection", "HirliteError", "__version__"]
 
 
 class Rlite(RliteExtension):

--- a/hirlite/patch_conn.py
+++ b/hirlite/patch_conn.py
@@ -1,0 +1,120 @@
+import hirlite
+
+try:
+    import redis
+    no_redis = False
+    from redis.connection import Connection
+    from redis.connection import ConnectionPool
+except ImportError:
+    Connection = object
+    ConnectionPool = object
+    no_redis = True
+
+try:
+    from queue import Queue
+except:
+    from Queue import Queue
+
+
+# ============================================================================
+class RliteConnection(Connection):
+    """
+    A subclass of redis-py Connection object to allow using redis-py interface
+    with rlite-py
+
+    """
+    filename = ':memory:'
+
+    @classmethod
+    def set_file(cls, filename):
+        cls.filename = filename
+
+    def __init__(self, *args, **kwargs):
+        super(RliteConnection, self).__init__(*args, **kwargs)
+        self.rlite = hirlite.Rlite(path=self.filename)
+        self.q = Queue()
+
+        if self.db:
+            self.send_command('SELECT', self.db)
+            self.read_response()
+
+    def can_read(self):
+        return True
+
+    def send_command(self, *args):
+        #print(args)
+        args = [self.encode(arg) for arg in args]
+
+        # implement SCAN via a KEYS call as rlite does not
+        # currently support SCAN
+        if args[0] == b'SCAN':
+            args = (b'KEYS', args[3])
+            result = self.rlite.command(*args)
+            result = [b'0', result]
+        else:
+            result = self.rlite.command(*args)
+
+        if isinstance(result, hirlite.HirliteError):
+            print(result)
+            raise result
+        else:
+            #print(result)
+            self.q.put(result)
+
+    def pack_commands(self, *args):
+        return args
+
+    def send_packed_command(self, command):
+        for cmd in command[0]:
+            self.send_command(*cmd)
+
+    def read_response(self):
+        resp = self.q.get()
+        if type(resp) == bool:
+            return 'OK'
+
+        if self.decode_responses and self.encoding:
+            resp = self._do_decode(resp)
+
+        return resp
+
+    def _do_decode(self, resp):
+        if isinstance(resp, list):
+            return [self._do_decode(item) for item in resp]
+        elif isinstance(resp, bytes):
+            return resp.decode(self.encoding)
+        else:
+            return resp
+
+
+# ============================================================================
+class RliteConnectionPool(ConnectionPool):
+    """
+    ConnectionPool subclass that defaults to RliteConnection
+    """
+    def __init__(self, **kwargs):
+        kwargs['connection_class'] = RliteConnection
+        super(RliteConnectionPool, self).__init__(**kwargs)
+
+
+# ============================================================================
+def patch_connection(filename=':memory:'):
+    """
+    ``filename``: rlite filename to store db in, or memory
+    Patch the redis-py Connection and the
+    static from_url() of Redis and StrictRedis to use RliteConnection
+    """
+
+    if no_redis:
+        print("redis package not found, please install redis-py via 'pip install redis'")
+        return
+
+    RliteConnection.set_file(filename)
+
+    redis.connection.Connection = RliteConnection
+    redis.Connection = RliteConnection
+
+    redis.connection.ConnectionPool = RliteConnectionPool
+    redis.client.ConnectionPool = RliteConnectionPool
+    redis.ConnectionPool = RliteConnectionPool
+

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -11,4 +11,11 @@ def tests():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(rlite.RliteTest))
     suite.addTest(unittest.makeSuite(persistent.PersistentTest))
+
+    try:
+        from test import patch
+        suite.addTest(unittest.makeSuite(patch.PatchConnTest))
+    except ImportError:
+        pass
+
     return suite

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -15,6 +15,7 @@ def tests():
     try:
         from test import patch
         suite.addTest(unittest.makeSuite(patch.PatchConnTest))
+        suite.addTest(unittest.makeSuite(patch.PatchContextManagerTest))
     except ImportError:
         pass
 

--- a/test/patch.py
+++ b/test/patch.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+from unittest import *
+import os.path
+import sys
+
+import hirlite
+
+import redis
+
+
+class PatchConnTest(TestCase):
+    def setUp(self):
+        hirlite.patch_connection()
+
+    def test_basic(self):
+        r = redis.StrictRedis()
+        r.set('foo', 'bar')
+        self.assertEquals(b'bar', r.get('foo'))
+
+    def test_basic_string(self):
+        r = redis.StrictRedis(decode_responses=True)
+        r.set('foo', 'bar')
+        self.assertEquals('bar', r.get('foo'))
+
+    def test_hset_transaction(self):
+        r = redis.Redis(decode_responses=True)
+
+        self.assertEquals(0, r.hlen('key'))
+
+        with redis.utils.pipeline(r) as pi:
+            pi.hset('key', 'a', '0')
+            pi.hset('key', 'b', 1)
+            pi.hset('key', 'c', b'2')
+
+        res = r.hgetall('key')
+        self.assertEquals({'a': '0', 'b': '1', 'c': '2'}, res)
+
+    def test_from_url(self):
+        r = redis.StrictRedis.from_url('redis://localhost/1',
+                                       decode_responses=True)
+
+        r.set('foo', 'bar')
+        self.assertEquals('bar', r.get('foo'))
+
+
+    def test_keys(self):
+        r = redis.StrictRedis(decode_responses=True)
+
+        r.set('abc', 'foo')
+        r.zadd('zset', 0, 'text')
+        r.hset('hset', 'foo', 'bar')
+
+        res = r.keys('*')
+
+        self.assertEquals(set(['abc', 'zset', 'hset']), set(res))
+
+    def test_scan(self):
+        r = redis.StrictRedis(decode_responses=True)
+
+        r.set('abc', 'foo')
+        r.zadd('zset', 0, 'text')
+        r.hset('hset', 'foo', 'bar')
+
+        res = list(r.scan_iter(match='*set'))
+
+        self.assertEquals(set(['zset', 'hset']), set(res))
+
+


### PR DESCRIPTION
An attempt to support a subset of the redis-py api via monkey-patching, as requested in #4 

redis-py not added as dependency, error printed if its not installed.

Some basic tests included in test/patch.py.